### PR TITLE
Add `git_committer_name` & `git_committer_email`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - uses: WIPACrepo/wipac-dev-mypy-action@v1.1
 
   setup_builder:
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - run: pip install -r requirements-dev.txt
       - run: |
           pytest tests/test_setup_builder.py -vvv

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.10'
       - uses: WIPACrepo/wipac-dev-mypy-action@v1.1
 
   setup_builder:
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.10'
       - run: pip install -r requirements-dev.txt
       - run: |
           pytest tests/test_setup_builder.py -vvv

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ GitHub Action Package for Automating Python-Package Setup
 This GitHub Action prepares a repository to be GitHub-released and PyPI-published by the [Python Semantic Release GitHub Action](https://python-semantic-release.readthedocs.io/en/latest/). All that a user needs to do is define a few attributes in `setup.cfg` (see [*Main Configuration Modes*](#main-configuration-modes)).
 
 ### Details
-`setup.cfg` sections needed for publishing a package to PyPI are auto-generated, hyper-linked badges are added to the `README.md`, and the root directory's `requirements.txt` is overwritten/updated (by way of [pip-compile](https://github.com/jazzband/pip-tools)). Commits are git-pushed by the "github-actions" bot (github-actions@github.com).
+`setup.cfg` sections needed for publishing a package to PyPI are auto-generated, hyper-linked badges are added to the `README.md`, and the root directory's `requirements.txt` is overwritten/updated (by way of [pip-compile](https://github.com/jazzband/pip-tools)). Commits are git-pushed by the "github-actions" bot (github-actions@github.com) by default, or your chosen actor configured by inputs (`git_committer_name` & `git_committer_email`).
 
 #### GitHub Action Syntax
 ```

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
   steps:
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.11'  # NOTE: update, someday. Also update tests.yml
+        python-version: '3.10'  # NOTE: update, someday
 
     - name: Git config
       run: |

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
   steps:
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.10'  # NOTE: update, someday
+        python-version: '3.11'  # NOTE: update, someday. Also update tests.yml
 
     - name: Git config
       run: |

--- a/action.yml
+++ b/action.yml
@@ -15,11 +15,11 @@ inputs:
     required: false
     default: 'MIT'
   git_committer_name:
-    description: 'The human name for the “committer” field'
+    description: 'The name used for "git config user.name"'
     required: false
     default: github-actions
   git_committer_email:
-    description: 'The email address for the “committer” field'
+    description: 'The email used for "git config user.email"'
     required: false
     default: github-actions@github.com
 

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
   steps:
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.10'  # NOTE: update, someday
+        python-version: '3.10'  # NOTE: update, someday. Also tests.yml
 
     - name: Git config
       run: |

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,14 @@ inputs:
     description: "The repo's license type"
     required: false
     default: 'MIT'
+  git_committer_name:
+    description: 'The human name for the “committer” field'
+    required: false
+    default: github-actions
+  git_committer_email:
+    description: 'The email address for the “committer” field'
+    required: false
+    default: github-actions@github.com
 
 # outputs:
 #   random-number:
@@ -29,8 +37,8 @@ runs:
 
     - name: Git config
       run: |
-        git config user.name github-actions
-        git config user.email github-actions@github.com
+        git config user.name ${{ inputs.git_committer_name }}
+        git config user.email ${{ inputs.git_committer_email }}
       shell: bash
 
     - name: Build setup.cfg + README.md (and commit)


### PR DESCRIPTION
This follows the convention used in https://github.com/python-semantic-release/python-semantic-release/blob/master/action.yml#L26-L31