### PR TITLE
Auto-create `py.typed` File(s)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
-      - uses: WIPACrepo/wipac-dev-flake8-action@v1
+      - uses: actions/setup-python@v4
+      - uses: WIPACrepo/wipac-dev-flake8-action@v1.0
 
   mypy:
     runs-on: ubuntu-latest
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - uses: WIPACrepo/wipac-dev-mypy-action@v1.1
+      - uses: WIPACrepo/wipac-dev-mypy-action@v1.2
 
   setup_builder:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # WIPACrepo/wipac-dev-py-setup-action
-GitHub Action Package for Automating Python-Package Setup
+GitHub Action Package for Automating Python-Package Setup & Maintenance
 
 
 
@@ -7,7 +7,11 @@ GitHub Action Package for Automating Python-Package Setup
 This GitHub Action prepares a repository to be GitHub-released and PyPI-published by the [Python Semantic Release GitHub Action](https://python-semantic-release.readthedocs.io/en/latest/). All that a user needs to do is define a few attributes in `setup.cfg` (see [*Main Configuration Modes*](#main-configuration-modes)).
 
 ### Details
-`setup.cfg` sections needed for publishing a package to PyPI are auto-generated, hyper-linked badges are added to the `README.md`, and the root directory's `requirements.txt` is overwritten/updated (by way of [pip-compile](https://github.com/jazzband/pip-tools)). Commits are git-pushed by the "github-actions" bot (github-actions@github.com) by default, or your chosen actor configured by inputs (`git_committer_name` & `git_committer_email`).
+- `setup.cfg` sections needed for publishing a package to PyPI are auto-generated,
+- hyper-linked badges are added to the `README.md`,
+- the root directory's `requirements.txt` is overwritten/updated (by way of [pip-compile](https://github.com/jazzband/pip-tools)) along with dedicated `requirements-EXTRA.txt` files for each package "extra", and
+- `py.typed` files are created as needed.
+Commits are git-pushed by the "github-actions" bot (github-actions@github.com) by default, or your chosen actor configured by inputs (`git_committer_name` & `git_committer_email`).
 
 #### GitHub Action Syntax
 ```

--- a/action.yml
+++ b/action.yml
@@ -71,7 +71,7 @@ runs:
         with open("setup.cfg") as f:
           for line in f.readlines():
             if line.startswith("version_variable = "):
-              line_to_parse = line
+              line_to_parse = line.strip()  # remove newline
         if not line_to_parse:
           raise Exception("Cannot addd py.typed files (missing version_variable in setup.cfg)")
 

--- a/action.yml
+++ b/action.yml
@@ -75,15 +75,13 @@ runs:
         if not line_to_parse:
           raise Exception("Cannot addd py.typed files (missing version_variable in setup.cfg)")
 
-        dirs = []
         for version_path in line_to_parse.removeprefix("version_variable = ").split(","):
           print(version_path)
           dpath = version_path.removesuffix("__init__.py:__version__")
           print(dpath)
-          dirs.append(dpath)
-
-        for dpath in dirs:
-          Path(dpath).touch()  # create if needed!
+          fpath = Path(dpath) / "py.typed"
+          print(fpath)
+          fpath.touch()  # create if needed!
         '
         git add .  # won't error if nothing to add
         git commit -m "<bot> add py.typed file(s)" || true

--- a/action.yml
+++ b/action.yml
@@ -77,7 +77,10 @@ runs:
 
         dirs = []
         for version_path in line_to_parse.removeprefix("version_variable = ").split(","):
-          dirs.append(version_path.removesuffix("__init__.py:__version__"))
+          print(version_path)
+          dpath = version_path.removesuffix("__init__.py:__version__")
+          print(dpath)
+          dirs.append(dpath)
 
         for dpath in dirs:
           Path(dpath).touch()  # create if needed!

--- a/action.yml
+++ b/action.yml
@@ -61,6 +61,32 @@ runs:
         git commit -m "<bot> update README.md" || true
       shell: bash
 
+    - name: Add py.typed file(s) (and commit)
+      run: |
+        python -c '
+        import os
+        from pathlib import Path
+
+        line_to_parse = ""
+        with open("setup.cfg") as f:
+          for line in f.readlines():
+            if line.startswith("version_variable = "):
+              line_to_parse = line
+        if not line_to_parse:
+          raise Exception("Cannot addd py.typed files (missing version_variable in setup.cfg)")
+
+        dirs = []
+        for version_path in line_to_parse.removeprefix("version_variable = ").split(","):
+          dirs.append(version_path.removesuffix("__init__.py:__version__"))
+
+        for dpath in dirs:
+          Path(dpath).touch()  # create if needed!
+        '
+        git add .  # won't error if nothing to add
+        git commit -m "<bot> add py.typed file(s)" || true
+
+      shell: bash
+
     - name: Build requirements.txt (and commit)
       run: |
         pip3 install pip-tools


### PR DESCRIPTION
Most useful for PyPI-bound pacakges, `py.typed` files need to be included in each package directory. They are empty files that tell Python's `typing` module to use/look for the package's typehints. This PR automates this boilerplate process.