### PR TITLE
Hot Fix: Exit Status

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ runs:
 
     - name: Is this the most recent commit? It won't be if the action was reran
       run: |
-        git fetch > /dev/null
+        git fetch &> /dev/null
         if [[ $(git status -sb | grep behind) ]]; then
           echo "IS_GIT_BEHIND=true" >> $GITHUB_ENV
           echo "this commit is not the most recent on this branch -- rest of action will be skipped"

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ runs:
 
     - name: Is this the most recent commit? It won't be if the action was reran
       run: |
-        git fetch
+        git fetch > /dev/null
         if [[ $(git status -sb | grep behind) ]]; then
           echo "IS_GIT_BEHIND=true" >> $GITHUB_ENV
           echo "this commit is not the most recent on this branch -- rest of action will be skipped"

--- a/action.yml
+++ b/action.yml
@@ -47,10 +47,12 @@ runs:
         git fetch
         if [[ $(git status -sb | grep behind) ]]; then
           echo "IS_GIT_BEHIND=true" >> $GITHUB_ENV
+          echo "this commit is not the most recent on this branch -- rest of action will be skipped"
         fi
       shell: bash
 
     - name: Git config
+      if: env.IS_GIT_BEHIND != 'true'
       run: |
         git config user.name ${{ inputs.git_committer_name }}
         git config user.email ${{ inputs.git_committer_email }}

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,14 @@ runs:
       with:
         python-version: '3.11'  # NOTE: update, someday. Also tests.yml
 
+    - name: Is this the most recent commit? It won't be if the action was reran
+      run: |
+        git fetch
+        if [[ $(git status -sb | grep behind) ]]; then
+          echo "IS_GIT_BEHIND=true" >> $GITHUB_ENV
+        fi
+      shell: bash
+
     - name: Git config
       run: |
         git config user.name ${{ inputs.git_committer_name }}
@@ -49,6 +57,7 @@ runs:
       shell: bash
 
     - name: Build setup.cfg + README.md (and commit)
+      if: env.IS_GIT_BEHIND != 'true'
       run: |
         pip3 install -r ${{ github.action_path }}/requirements.txt
         pip3 install wipac-dev-tools
@@ -77,6 +86,7 @@ runs:
       shell: bash
 
     - name: Add py.typed file(s) (and commit)
+      if: env.IS_GIT_BEHIND != 'true'
       run: |
         python -c '
         import os
@@ -104,6 +114,7 @@ runs:
       shell: bash
 
     - name: Build dependencies.log (and commit)
+      if: env.IS_GIT_BEHIND != 'true'
       run: |
         # append permissive line to .gitignore since *.log is commonly present
         line='!dependencies*.log'
@@ -142,6 +153,7 @@ runs:
       shell: bash
 
     - name: Push changes
+      if: env.IS_GIT_BEHIND != 'true'
       run: |
         status=`git status 2>&1 | tee`
         ahead=`echo -n "${status}" 2> /dev/null | grep "Your branch is ahead of" &> /dev/null; echo "$?"`

--- a/action.yml
+++ b/action.yml
@@ -165,5 +165,4 @@ runs:
         fi
         git push
         echo "changes pushed"
-        sleep 10  # allow any git-aware actions (that are pending) to see they're behind & act (exit) accordingly
       shell: bash


### PR DESCRIPTION
The action will no longer fail in the following cases:
- the action is reran & its commit is behind (was :x:)
- the action is successful & the workflow uses concurrency (was canceled :no_entry_sign:)