### PR TITLE
Use `pip-compile` with `--cache-dir`

### DIFF
--- a/build-dependencies-logs.sh
+++ b/build-dependencies-logs.sh
@@ -12,13 +12,17 @@ set -e
 pip3 install --upgrade pip
 pip3 install pip-tools
 
+PIPTOOLSCACHE=./pip-tools-cache
+mkdir -p $PIPTOOLSCACHE
+trap 'rm -rf "$PIPTOOLSCACHE"' EXIT
+
 # do main dependencies.log in subproc
 echo
 file="dependencies.log"
 echo $file
 git mv requirements.txt $file 2> /dev/null || true  # don't want requirements.txt
 echo "pip-compile..."
-pip-compile --upgrade --output-file="$file" --cache-dir="$file"-pip-tools-cache"$file" &
+pip-compile --upgrade --output-file="$file" --cache-dir="$PIPTOOLSCACHE/$file" &
 
 # get all extras
 EXTRAS=$(python3 $GITHUB_ACTION_PATH/list_extras.py setup.cfg)
@@ -30,7 +34,7 @@ for extra in $EXTRAS; do
   echo $file
   git mv "requirements-${extra}.txt" $file 2> /dev/null || true  # don't want requirements*.txt
   echo "pip-compile..."
-  pip-compile --upgrade --extra $extra --output-file="$file" --cache-dir="$file"-pip-tools-cache"$file" &
+  pip-compile --upgrade --extra $extra --output-file="$file" --cache-dir="$PIPTOOLSCACHE/$file" &
 done
 echo
 

--- a/build-dependencies-logs.sh
+++ b/build-dependencies-logs.sh
@@ -30,6 +30,7 @@ for extra in $EXTRAS; do
   echo $file
   git mv "requirements-${extra}.txt" $file 2> /dev/null || true  # don't want requirements*.txt
   echo "pip-compile..."
+  sleep 5
   pip-compile --upgrade --extra $extra --output-file="$file" &
 done
 echo

--- a/build-dependencies-logs.sh
+++ b/build-dependencies-logs.sh
@@ -18,7 +18,7 @@ file="dependencies.log"
 echo $file
 git mv requirements.txt $file 2> /dev/null || true  # don't want requirements.txt
 echo "pip-compile..."
-pip-compile --upgrade --output-file="$file" &
+pip-compile --upgrade --output-file="$file" --cache-dir="$file"-pip-tools-cache"$file" &
 
 # get all extras
 EXTRAS=$(python3 $GITHUB_ACTION_PATH/list_extras.py setup.cfg)
@@ -30,8 +30,7 @@ for extra in $EXTRAS; do
   echo $file
   git mv "requirements-${extra}.txt" $file 2> /dev/null || true  # don't want requirements*.txt
   echo "pip-compile..."
-  pip-compile --upgrade --extra $extra --output-file="$file" &
-  sleep 5
+  pip-compile --upgrade --extra $extra --output-file="$file" --cache-dir="$file"-pip-tools-cache"$file" &
 done
 echo
 

--- a/build-dependencies-logs.sh
+++ b/build-dependencies-logs.sh
@@ -22,7 +22,7 @@ file="dependencies.log"
 echo $file
 git mv requirements.txt $file 2> /dev/null || true  # don't want requirements.txt
 echo "pip-compile..."
-pip-compile --upgrade --output-file="$file" --cache-dir="$PIPTOOLSCACHE/$file" &
+pip-compile --upgrade --output-file="$file" --cache-dir="$PIPTOOLSCACHE/$(echo $file | sed -r 's/./-/g')" &
 
 # get all extras
 EXTRAS=$(python3 $GITHUB_ACTION_PATH/list_extras.py setup.cfg)
@@ -34,7 +34,7 @@ for extra in $EXTRAS; do
   echo $file
   git mv "requirements-${extra}.txt" $file 2> /dev/null || true  # don't want requirements*.txt
   echo "pip-compile..."
-  pip-compile --upgrade --extra $extra --output-file="$file" --cache-dir="$PIPTOOLSCACHE/$file" &
+  pip-compile --upgrade --extra $extra --output-file="$file" --cache-dir="$PIPTOOLSCACHE/$(echo $file | sed -r 's/./-/g')" &
 done
 echo
 

--- a/build-dependencies-logs.sh
+++ b/build-dependencies-logs.sh
@@ -22,7 +22,7 @@ file="dependencies.log"
 echo $file
 git mv requirements.txt $file 2> /dev/null || true  # don't want requirements.txt
 echo "pip-compile..."
-pip-compile --upgrade --output-file="$file" --cache-dir="$PIPTOOLSCACHE/$(echo $file | sed -r 's/./-/g')" &
+pip-compile --upgrade --output-file="$file" --cache-dir="$PIPTOOLSCACHE/$(echo $file | sed -r 's/\./-/g')" &
 
 # get all extras
 EXTRAS=$(python3 $GITHUB_ACTION_PATH/list_extras.py setup.cfg)
@@ -34,7 +34,7 @@ for extra in $EXTRAS; do
   echo $file
   git mv "requirements-${extra}.txt" $file 2> /dev/null || true  # don't want requirements*.txt
   echo "pip-compile..."
-  pip-compile --upgrade --extra $extra --output-file="$file" --cache-dir="$PIPTOOLSCACHE/$(echo $file | sed -r 's/./-/g')" &
+  pip-compile --upgrade --extra $extra --output-file="$file" --cache-dir="$PIPTOOLSCACHE/$(echo $file | sed -r 's/\./-/g')" &
 done
 echo
 

--- a/build-dependencies-logs.sh
+++ b/build-dependencies-logs.sh
@@ -30,8 +30,8 @@ for extra in $EXTRAS; do
   echo $file
   git mv "requirements-${extra}.txt" $file 2> /dev/null || true  # don't want requirements*.txt
   echo "pip-compile..."
-  sleep 5
   pip-compile --upgrade --extra $extra --output-file="$file" &
+  sleep 5
 done
 echo
 


### PR DESCRIPTION
There looks to be a race condition that results in 
```
pip._internal.exceptions.HashMismatch: THESE PACKAGES DO NOT MATCH THE HASHES FROM THE REQUIREMENTS FILE. If you have updated the package versions, please update the hashes. Otherwise, examine the package contents carefully; someone may have tampered with them.
    unknown package:
        Expected sha256 <hash>
             Got        <hash>
```
when there are dependencies that resolve to different versions depending on their install-extra.